### PR TITLE
bump vite to 4.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"@sveltejs/adapter-cloudflare": "^2.2.0",
 		"@sveltejs/kit": "^1.5.0",
 		"svelte": "^3.54.0",
-		"vite": "^4.2.0"
+		"vite": "^4.3.9"
 	},
 	"type": "module",
 	"dependencies": {


### PR DESCRIPTION
Older version has major security issues, see CVE-2023-34092